### PR TITLE
Added the possibility to set reminder times for single issues.

### DIFF
--- a/app/views/issues/_attributes.html.erb
+++ b/app/views/issues/_attributes.html.erb
@@ -1,0 +1,77 @@
+<%= labelled_fields_for :issue, @issue do |f| %>
+
+<div class="splitcontent">
+<div class="splitcontentleft">
+<% if @issue.safe_attribute?('status_id') && @allowed_statuses.present? %>
+<p><%= f.select :status_id, (@allowed_statuses.collect {|p| [p.name, p.id]}), {:required => true},
+                :onchange => "updateIssueFrom('#{escape_javascript project_issue_form_path(@project, :id => @issue, :format => 'js')}')" %></p>
+
+<% else %>
+<p><label><%= l(:field_status) %></label> <%= h(@issue.status.name) %></p>
+<% end %>
+
+<% if @issue.safe_attribute? 'priority_id' %>
+<p><%= f.select :priority_id, (@priorities.collect {|p| [p.name, p.id]}), {:required => true}, :disabled => !@issue.leaf? %></p>
+<% end %>
+
+<% if @issue.safe_attribute? 'assigned_to_id' %>
+<p><%= f.select :assigned_to_id, principals_options_for_select(@issue.assignable_users, @issue.assigned_to), :include_blank => true, :required => @issue.required_attribute?('assigned_to_id') %></p>
+<% end %>
+
+<% if @issue.safe_attribute?('category_id') && @issue.project.issue_categories.any? %>
+<p><%= f.select :category_id, (@issue.project.issue_categories.collect {|c| [c.name, c.id]}), :include_blank => true, :required => @issue.required_attribute?('category_id') %>
+<%= link_to(image_tag('add.png', :style => 'vertical-align: middle;'),
+            new_project_issue_category_path(@issue.project),
+            :remote => true,
+            :method => 'get',
+            :title => l(:label_issue_category_new),
+            :tabindex => 200) if User.current.allowed_to?(:manage_categories, @issue.project) %></p>
+<% end %>
+
+<% if @issue.safe_attribute?('fixed_version_id') && @issue.assignable_versions.any? %>
+<p><%= f.select :fixed_version_id, version_options_for_select(@issue.assignable_versions, @issue.fixed_version), :include_blank => true, :required => @issue.required_attribute?('fixed_version_id') %>
+<%= link_to(image_tag('add.png', :style => 'vertical-align: middle;'),
+            new_project_version_path(@issue.project),
+            :remote => true,
+            :method => 'get',
+            :title => l(:label_version_new),
+            :tabindex => 200) if User.current.allowed_to?(:manage_versions, @issue.project) %>
+</p>
+<% end %>
+</div>
+
+<div class="splitcontentright">
+<% if @issue.safe_attribute? 'parent_issue_id' %>
+<p id="parent_issue"><%= f.text_field :parent_issue_id, :size => 10, :required => @issue.required_attribute?('parent_issue_id') %></p>
+<%= javascript_tag "observeAutocompleteField('issue_parent_issue_id', '#{escape_javascript auto_complete_issues_path}')" %>
+<% end %>
+
+<% if @issue.safe_attribute? 'start_date' %>
+<p><%= f.text_field :start_date, :size => 10, :disabled => !@issue.leaf?, :required => @issue.required_attribute?('start_date') %><%= calendar_for('issue_start_date') if @issue.leaf? %></p>
+<% end %>
+
+<% if @issue.safe_attribute? 'due_date' %>
+<p><%= f.text_field :due_date, :size => 10, :disabled => !@issue.leaf?, :required => @issue.required_attribute?('due_date') %><%= calendar_for('issue_due_date') if @issue.leaf? %></p>
+<% end %>
+
+<% if @issue.safe_attribute? 'estimated_hours' %>
+<p><%= f.text_field :estimated_hours, :size => 3, :disabled => !@issue.leaf?, :required => @issue.required_attribute?('estimated_hours') %> <%= l(:field_hours) %></p>
+<% end %>
+
+<% if @issue.safe_attribute?('done_ratio') && @issue.leaf? && Issue.use_field_for_done_ratio? %>
+<p><%= f.select :done_ratio, ((0..10).to_a.collect {|r| ["#{r*10} %", r*10] }), :required => @issue.required_attribute?('done_ratio') %></p>
+<% end %>
+
+<% if @issue.safe_attribute? 'reminder_notification' %>
+<p><%= f.text_field :reminder_notification, :size => 10 %></p>
+<% end %>
+</div>
+</div>
+
+<% if @issue.safe_attribute? 'custom_field_values' %>
+<%= render :partial => 'issues/form_custom_fields' %>
+<% end %>
+
+<% end %>
+
+<% include_calendar_headers_tags %>

--- a/db/migrate/0003_add_issue_reminder_notification.rb
+++ b/db/migrate/0003_add_issue_reminder_notification.rb
@@ -1,0 +1,10 @@
+class AddIssueReminderNotification < ActiveRecord::Migration
+
+  def self.up
+    add_column(:issues, "reminder_notification", :string)
+  end
+
+  def self.down
+    remove_column(:issues, "reminder_notification")
+  end
+end

--- a/lib/reminder/issue_patch.rb
+++ b/lib/reminder/issue_patch.rb
@@ -2,23 +2,39 @@ module Reminder
   module IssuePatch
     def self.included(base)
       base.send(:include, InstanceMethods)
+      base.class_eval do
+        # Same as typing in the class.
+        unloadable # Send unloadable so it will not be unloaded in development.
+        safe_attributes 'reminder_notification'
+        validates_format_of :reminder_notification, :with => /\A\s*(\d+(\s*,\s*\d+)*)?\z/, :on => :update
+      end
     end
   end
 
   module InstanceMethods
+
+    def reminder_notification_array
+      unless reminder_notification.blank?
+        return reminder_notification.split(%r{[\s,\s]}).collect(&:to_i).uniq.select { |n| n >= 0 }.sort
+      end
+      []
+    end
+
     def days_before_due_date
       (due_date - Date.today).to_i
     end
 
     def remind?
       if assigned_to.present?
-        if category.present? && category.reminder_notification_array.any?
+        if reminder_notification_array.any? then
+          return reminder_notification_array.include?(days_before_due_date)
+        elsif category.present? && category.reminder_notification_array.any? then
           return category.reminder_notification_array.include?(days_before_due_date)
         else
           return assigned_to.reminder_notification_array.include?(days_before_due_date)
         end
       end
-      false
+      return false
     end
   end
 end


### PR DESCRIPTION
Added the possibility to set reminder days specific to each issue, overriding the category, user and global settings.

The first specified non-empty times from this list are used to determine the days on which a reminder is sent:
1. Issue reminder times
2. Issue category reminder times
3. User reminder times
4. Global reminder times
